### PR TITLE
add FormattableString.Invariant to ICommand.ToString()

### DIFF
--- a/SvgPathProperties.UnitTests/ToStringTests.cs
+++ b/SvgPathProperties.UnitTests/ToStringTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Globalization;
+
+using Xunit;
+
+namespace SvgPathProperties.UnitTests
+{
+    public class ToStringTests
+    {
+        [Theory]
+        //with . separator
+        [InlineData("en-US", 0, 1.5, 0, 1.5, "L 1.5 1.5")]
+
+        [InlineData("en-US", 0, 1_000_000.5, 0, 1.5, "L 1000000.5 1.5")]
+        //with , separator
+        [InlineData("de-DE", 0, 1.5, 0, 1.5, "L 1.5 1.5")]
+        [InlineData("it-IT", 0, 1.5, 0, 1.5, "L 1.5 1.5")]
+        [InlineData("es-ES", 0, 1.5, 0, 1.5, "L 1.5 1.5")]
+        [InlineData("nl-BE", 0, 1.5, 0, 1.5, "L 1.5 1.5")]
+
+        [InlineData("de-DE", 0, 1_000_000.5, 0, 1_000_000.5, "L 1000000.5 1000000.5")]
+        [InlineData("it-IT", 0, 1_000_000.5, 0, 1_000_000.5, "L 1000000.5 1000000.5")]
+        [InlineData("es-ES", 0, 1_000_000.5, 0, 1_000_000.5, "L 1000000.5 1000000.5")]
+        [InlineData("nl-BE", 0, 1_000_000.5, 0, 1_000_000.5, "L 1000000.5 1000000.5")]
+        // with / separator
+        [InlineData("fa-IR", 0, 1.5, 0, 1.5, "L 1.5 1.5")]
+        [InlineData("fa-IR", 0, 1_000_000.5, 0, 1_000_000.5, "L 1000000.5 1000000.5")]
+        public void CuluresWithPointSeparator(string cultureCode, double fromX, double toX, double fromY, double toY, string result)
+        {
+            var command = new LineCommand(fromX, toX, fromY, toY);
+            CultureInfo.CurrentCulture = new CultureInfo(cultureCode); ;
+
+            Assert.Equal(result, command.ToString());
+        }
+    }
+}

--- a/SvgPathProperties/ArcCommand.cs
+++ b/SvgPathProperties/ArcCommand.cs
@@ -1,4 +1,5 @@
 ﻿using SvgPathProperties.Base;
+
 using System;
 
 namespace SvgPathProperties
@@ -267,7 +268,7 @@ namespace SvgPathProperties
 
         public override string ToString()
         {
-            return $"A {Rx} {Ry} {XAxisRotate} {Convert.ToInt32(LargeArcFlag)} {Convert.ToInt32(SweepFlag)} {ToX} {ToY}";
+            return FormattableString.Invariant($"A {Rx} {Ry} {XAxisRotate} {Convert.ToInt32(LargeArcFlag)} {Convert.ToInt32(SweepFlag)} {ToX} {ToY}");
         }
     }
 }

--- a/SvgPathProperties/BezierCommand.cs
+++ b/SvgPathProperties/BezierCommand.cs
@@ -1,4 +1,5 @@
 ﻿using SvgPathProperties.Base;
+
 using System;
 
 namespace SvgPathProperties
@@ -153,11 +154,11 @@ namespace SvgPathProperties
         {
             if (IsQuadratic)
             {
-                return $"Q {Cp1.X} {Cp1.Y} {Cp2OrEnd.X} {Cp2OrEnd.Y}";
+                return FormattableString.Invariant($"Q {Cp1.X} {Cp1.Y} {Cp2OrEnd.X} {Cp2OrEnd.Y}");
             }
             else
             {
-                return $"C {Cp1.X} {Cp1.Y} {Cp2OrEnd.X} {Cp2OrEnd.Y} {End.X} {End.Y}";
+                return FormattableString.Invariant($"C {Cp1.X} {Cp1.Y} {Cp2OrEnd.X} {Cp2OrEnd.Y} {End.X} {End.Y}");
             }
         }
     }

--- a/SvgPathProperties/LineCommand.cs
+++ b/SvgPathProperties/LineCommand.cs
@@ -1,4 +1,5 @@
 ﻿using SvgPathProperties.Base;
+
 using System;
 
 namespace SvgPathProperties
@@ -55,7 +56,7 @@ namespace SvgPathProperties
 
         public override string ToString()
         {
-            return ClosePath ? "Z" : $"L {ToX} {ToY}";
+            return ClosePath ? "Z" : FormattableString.Invariant($"L {ToX} {ToY}");
         }
     }
 }

--- a/SvgPathProperties/MoveCommand.cs
+++ b/SvgPathProperties/MoveCommand.cs
@@ -1,5 +1,7 @@
 using SvgPathProperties.Base;
 
+using System;
+
 namespace SvgPathProperties
 {
     public class MoveCommand : ICommand
@@ -33,7 +35,7 @@ namespace SvgPathProperties
 
         public override string ToString()
         {
-            return $"M {X} {Y}";
+            return FormattableString.Invariant($"M {X} {Y}");
         }
     }
 }


### PR DESCRIPTION
Path Strings had commas as decimal separator when culture was set to "de-DE" or similar cultures